### PR TITLE
feat: add categorized glossary selection

### DIFF
--- a/src/components/CylinderGlossary.js
+++ b/src/components/CylinderGlossary.js
@@ -1,11 +1,12 @@
 // src/components/CylinderGlossary.js
 import React, { useState } from 'react';
 import { glossaryData } from '../data/glossaryData';
+import { glossaryCategories } from '../data/glossaryCategories';
 import CylinderBreakdown from './CylinderBreakdown';
 import './CylinderGlossary.css';
 
 function CylinderGlossary() {
-  const [selectedCylinderId, setSelectedCylinderId] = useState(glossaryData.cylinderTypes[0].id);
+  const [selectedCylinderId, setSelectedCylinderId] = useState(glossaryCategories[0].options[0].id);
 
   const selectedCylinder = glossaryData.cylinderTypes.find(c => c.id === selectedCylinderId);
 
@@ -20,19 +21,25 @@ function CylinderGlossary() {
           onChange={(e) => setSelectedCylinderId(e.target.value)}
           className="glossary-selector-select"
         >
-          {glossaryData.cylinderTypes.map(cylinder => (
-            <option key={cylinder.id} value={cylinder.id}>
-              {cylinder.name}
-            </option>
+          {glossaryCategories.map(group => (
+            <optgroup key={group.label} label={group.label}>
+              {group.options.map(option => (
+                <option key={option.id} value={option.id}>
+                  {option.name}
+                </option>
+              ))}
+            </optgroup>
           ))}
         </select>
       </div>
 
-      {selectedCylinder && (
+      {selectedCylinder && selectedCylinder.parts.length > 0 ? (
         <CylinderBreakdown
           imageUrl={selectedCylinder.imageUrl}
           parts={selectedCylinder.parts}
         />
+      ) : (
+        <p className="no-parts-message">No parts available for this selection.</p>
       )}
     </div>
   );

--- a/src/data/glossaryCategories.js
+++ b/src/data/glossaryCategories.js
@@ -1,0 +1,31 @@
+// src/data/glossaryCategories.js
+
+export const glossaryCategories = [
+  {
+    label: 'Conventional',
+    options: [
+      { id: 'standard-conventional', name: 'Standard Conventional' },
+      { id: 'degree-conventional', name: 'Degree Conventional' },
+      { id: 'xc-conventional', name: 'XC Conventional' },
+      { id: 'keso-conventional', name: 'KESO Conventional' },
+    ],
+  },
+  {
+    label: 'LFIC',
+    options: [
+      { id: 'standard-lfic', name: 'Standard LFIC' },
+      { id: 'degree-lfic', name: 'Degree LFIC' },
+      { id: 'xc-lfic', name: 'XC LFIC' },
+      { id: 'keso-lfic', name: 'KESO LFIC' },
+    ],
+  },
+  {
+    label: 'SFIC',
+    options: [
+      { id: 'standard-sfic', name: 'Standard SFIC' },
+      { id: 'degree-sfic', name: 'Degree SFIC' },
+      { id: 'xc-sfic', name: 'XC SFIC' },
+      { id: 'keso-sfic', name: 'KESO SFIC' },
+    ],
+  },
+];

--- a/src/data/glossaryData.js
+++ b/src/data/glossaryData.js
@@ -3,6 +3,18 @@ import { images } from '../images/images';
 
 export const glossaryData = {
   cylinderTypes: [
+    { id: 'standard-conventional', name: 'Standard Conventional', imageUrl: null, parts: [] },
+    { id: 'degree-conventional', name: 'Degree Conventional', imageUrl: null, parts: [] },
+    { id: 'xc-conventional', name: 'XC Conventional', imageUrl: null, parts: [] },
+    { id: 'keso-conventional', name: 'KESO Conventional', imageUrl: null, parts: [] },
+    { id: 'standard-lfic', name: 'Standard LFIC', imageUrl: null, parts: [] },
+    { id: 'degree-lfic', name: 'Degree LFIC', imageUrl: null, parts: [] },
+    { id: 'xc-lfic', name: 'XC LFIC', imageUrl: null, parts: [] },
+    { id: 'keso-lfic', name: 'KESO LFIC', imageUrl: null, parts: [] },
+    { id: 'standard-sfic', name: 'Standard SFIC', imageUrl: null, parts: [] },
+    { id: 'degree-sfic', name: 'Degree SFIC', imageUrl: null, parts: [] },
+    { id: 'xc-sfic', name: 'XC SFIC', imageUrl: null, parts: [] },
+    { id: 'keso-sfic', name: 'KESO SFIC', imageUrl: null, parts: [] },
     {
       id: 'mortise',
       name: 'Mortise Cylinder',


### PR DESCRIPTION
## Summary
- add placeholder categories for conventional, LFIC, and SFIC
- group cylinder glossary select by new categories
- show message when no parts available for selection

## Testing
- `npm test -- --watchAll=false` *(fails: Unable to find an element with the text: /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_6895435a9a6c8333909dac7c21c35589