### PR TITLE
Refine cylinder glossary selection

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders app title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/sargent cylinders/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/components/CylinderGlossary.js
+++ b/src/components/CylinderGlossary.js
@@ -6,33 +6,22 @@ import CylinderBreakdown from './CylinderBreakdown';
 import './CylinderGlossary.css';
 
 function CylinderGlossary() {
-
   const cylinderOptions = ['mortise', 'bored-locks', 'rim']
     .map((id) => glossaryData.cylinderTypes.find((c) => c.id === id))
     .filter(Boolean);
+
   const [selectedTypeId, setSelectedTypeId] = useState(cylinderOptions[0].id);
-  const [selectedCategoryId, setSelectedCategoryId] = useState(
-    glossaryCategories[0].options[0].id
-  );
+  const [selectedCategoryId, setSelectedCategoryId] = useState(glossaryCategories[0].id);
 
-  const [selectedCylinderId, setSelectedCylinderId] = useState(glossaryCategories[0].options[0].id);
-
-
-  const selectedCylinder = cylinderOptions.find(c => c.id === selectedTypeId);
-  const showParts =
-    selectedCategoryId === 'standard-conventional' &&
-    selectedCylinder &&
-    selectedCylinder.parts.length > 0;
+  const selectedCylinder = cylinderOptions.find((c) => c.id === selectedTypeId);
+  const showParts = selectedCylinder && selectedCylinder.parts.length > 0;
 
   return (
     <div className="glossary-container">
       <h2 className="glossary-title">Cylinder Parts Glossary</h2>
 
       <div className="glossary-selector-container">
-        <label
-          htmlFor="type-select"
-          className="glossary-selector-label"
-        >
+        <label htmlFor="type-select" className="glossary-selector-label">
           Select cylinder:
         </label>
         <select
@@ -41,28 +30,17 @@ function CylinderGlossary() {
           onChange={(e) => setSelectedTypeId(e.target.value)}
           className="glossary-selector-select"
         >
-          {cylinderOptions.map(option => (
+          {cylinderOptions.map((option) => (
             <option key={option.id} value={option.id}>
               {option.name}
             </option>
-          {glossaryCategories.map(group => (
-            <optgroup key={group.label} label={group.label}>
-              {group.options.map(option => (
-                <option key={option.id} value={option.id}>
-                  {option.name}
-                </option>
-              ))}
-            </optgroup>
           ))}
         </select>
       </div>
 
       <div className="glossary-selector-container">
-        <label
-          htmlFor="category-select"
-          className="glossary-selector-label"
-        >
-          Select category:
+        <label htmlFor="category-select" className="glossary-selector-label">
+          Select type:
         </label>
         <select
           id="category-select"
@@ -70,20 +48,15 @@ function CylinderGlossary() {
           onChange={(e) => setSelectedCategoryId(e.target.value)}
           className="glossary-selector-select"
         >
-          {glossaryCategories.map(group => (
-            <optgroup key={group.label} label={group.label}>
-              {group.options.map(option => (
-                <option key={option.id} value={option.id}>
-                  {option.name}
-                </option>
-              ))}
-            </optgroup>
+          {glossaryCategories.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.name}
+            </option>
           ))}
         </select>
       </div>
 
       {showParts ? (
-      {selectedCylinder && selectedCylinder.parts.length > 0 ? (
         <CylinderBreakdown
           imageUrl={selectedCylinder.imageUrl}
           parts={selectedCylinder.parts}
@@ -96,3 +69,4 @@ function CylinderGlossary() {
 }
 
 export default CylinderGlossary;
+

--- a/src/data/glossaryCategories.js
+++ b/src/data/glossaryCategories.js
@@ -1,31 +1,10 @@
 // src/data/glossaryCategories.js
 
+// Category options shared by all cylinder types
 export const glossaryCategories = [
-  {
-    label: 'Conventional',
-    options: [
-      { id: 'standard-conventional', name: 'Standard Conventional' },
-      { id: 'degree-conventional', name: 'Degree Conventional' },
-      { id: 'xc-conventional', name: 'XC Conventional' },
-      { id: 'keso-conventional', name: 'KESO Conventional' },
-    ],
-  },
-  {
-    label: 'LFIC',
-    options: [
-      { id: 'standard-lfic', name: 'Standard LFIC' },
-      { id: 'degree-lfic', name: 'Degree LFIC' },
-      { id: 'xc-lfic', name: 'XC LFIC' },
-      { id: 'keso-lfic', name: 'KESO LFIC' },
-    ],
-  },
-  {
-    label: 'SFIC',
-    options: [
-      { id: 'standard-sfic', name: 'Standard SFIC' },
-      { id: 'degree-sfic', name: 'Degree SFIC' },
-      { id: 'xc-sfic', name: 'XC SFIC' },
-      { id: 'keso-sfic', name: 'KESO SFIC' },
-    ],
-  },
+  { id: 'standard', name: 'Standard' },
+  { id: 'degree', name: 'Degree' },
+  { id: 'xc', name: 'XC' },
+  { id: 'keso', name: 'KESO' },
 ];
+


### PR DESCRIPTION
## Summary
- Limit cylinder selector to Mortise, Bored Locks, and Rim
- Add second selector for Standard, Degree, XC, and KESO categories
- Update app test to check for application title

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68956004c8288333a88b7ea3a3888924